### PR TITLE
Adding front matter and adding space between image

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,7 +23,7 @@
     <header>
       <nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark">
         <div class="container">
-          <a class="navbar-brand" href="/"><img src="/assets/images/osglogo.png">Open Science Grid</a>
+          <a class="navbar-brand" href="/"><img src="/assets/images/osglogo.png"> Open Science Grid</a>
           <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
           </button>

--- a/index.md
+++ b/index.md
@@ -1,3 +1,6 @@
+---
+layout: default
+---
 
 {% include homepage_top.html %}
 


### PR DESCRIPTION
For jekyll to work correctly, a markdown file needs to have
yaml front matter.  Otherwise, it does not parse and convert
markdown to HTML.

Further, I added a space between the image and the OSG header.