### PR TITLE
Twiki decommissioning landing page

### DIFF
--- a/osg-twiki-decommissioned.md
+++ b/osg-twiki-decommissioned.md
@@ -1,0 +1,31 @@
+---
+title: OSG Twiki Decommisssioned
+---
+
+The OSG TWiki service has been decommissioned
+----------------------------------------------
+
+As of January 2017, the OSG TWiki service has been decommissioned and its resources have been moved.
+We apologize for any inconvenience this might have caused.  The following areas have been
+transitioned to a new hosting system:
+
+
+*  [Systems Administrator Documentation](https://opensciencegrid.github.io/docs/): This documentation
+   aims to provide OSG _site administrators_ with the necessary information to install, configure,
+   and operate site services.
+*  [User Support](https://support.opensciencegrid.org): Documentation and support for _researchers_
+   interested in using OSG resources.
+*  [Security](https://opensciencegrid.github.io/security): If you need to read about OSG Security
+   practices, procedures, or need to contact the security team.</li>
+*  [Networking](https://opensciencegrid.github.io/networking/): This is an entry point for those
+   interested in Networking in OSG/WLCG or for those OSG/WLCG users experiencing network problems.
+*  [Operations](https://opensciencegrid.github.io/operations/): Documentation with regards to OSG
+   Operations (SLAs, etc.)
+*  [Education](https://opensciencegrid.github.io/outreach/): OSG User School and other OSG teaching
+   or training events.
+*  [Technology](https://opensciencegrid.github.io/technology/): Current technologies that OSG uses
+   and plans for technology adoption in the future.
+
+If what you are looking for is not here, please contact us at [help@opensciencegrid.org](mailto:help@opensciencegrid.org)
+and we will be happy to assist you.</p>
+

--- a/osg-twiki-decommissioned.md
+++ b/osg-twiki-decommissioned.md
@@ -1,4 +1,5 @@
 ---
+layout: default
 title: OSG Twiki Decommisssioned
 ---
 


### PR DESCRIPTION
This provides the simple twiki landing page that twiki.opensciencegrid.org redirects to.