### PR TITLE
Add a landing page for a MyOSG and OIM redirect.

### DIFF
--- a/myosg-decommissioned.md
+++ b/myosg-decommissioned.md
@@ -8,10 +8,10 @@ The MyOSG and OIM services have been decommissioned
 ---------------------------------------------------
 
 As a part of the larger [spring 2018 service migration](https://opensciencegrid.org/technology/policy/service-migrations-spring-2018/),
-the OIM and MyOSG services at <oim.grid.iu.edu> and <myosg.grid.iu.edu> have
-been decommissioned.  We apologize for any inconvenience this might have caused.
+the OIM and MyOSG services at [oim.grid.iu.edu](https://oim.grid.iu.edu) and [myosg.grid.iu.edu](https://myosg.grid.iu.edu) have
+been decommissioned.  We apologize for any inconvenience.
 
-The MyOSG XML queries have been migrated to <https://my.opensciencegrid.org>; other than a hostname
+The MyOSG XML queries have been migrated to [my.opensciencegrid.org](https://my.opensciencegrid.org); other than a hostname
 change, the URL paths and query parameters are identical.  If you see any unexpected changes
 in the XML structure, please contact us at [help@opensciencegrid.org](mailto:help@opensciencegrid.org)
 and we will be happy to assist you.

--- a/myosg-decommissioned.md
+++ b/myosg-decommissioned.md
@@ -1,0 +1,21 @@
+---
+layout: default
+title: MyOSG and OIM Decomissioned
+redirect_from: /myosg-decommissioned/index.html
+---
+
+The MyOSG and OIM services have been decommissioned
+---------------------------------------------------
+
+As a part of the larger [spring 2018 service migration](https://opensciencegrid.org/technology/policy/service-migrations-spring-2018/),
+the OIM and MyOSG services at <oim.grid.iu.edu> and <myosg.grid.iu.edu> have
+been decommissioned.  We apologize for any inconvenience this might have caused.
+
+The MyOSG XML queries have been migrated to <https://my.opensciencegrid.org>; other than a hostname
+change, the URL paths and query parameters are identical.  If you see any unexpected changes
+in the XML structure, please contact us at [help@opensciencegrid.org](mailto:help@opensciencegrid.org)
+and we will be happy to assist you.
+
+The reference topology (sites, resource, and services) and contact information kept in OIM are now
+kept in internal repositories; if you need to make changes for your site, please contact
+[support@opensciencegrid.org](mailto:support@opensciencegrid.org).


### PR DESCRIPTION
This is a simple landing page (similar to the one for [twiki.opensciencegrid.org](twiki.opensciencegrid.org)) done in preparation for redirecting grid.iu.edu CNAMEs to opensciencegrid.org.