### PR TITLE
Fixing broken link to list of VOs

### DIFF
--- a/_about/organization.md
+++ b/_about/organization.md
@@ -4,7 +4,7 @@ title: Organization
 
 The OSG Consortium builds and operates the OSG. Consortium members contribute effort and resources to the common infrastructure, with the goal of giving scientists from many fields access to shared resources worldwide.
 
-Please see the [list of Virtual Organizations](http://my.opensciencegrid.org/vosummary?all_vos=on&active=on&active_value=1).
+Please see the [list of Virtual Organizations](https://github.com/opensciencegrid/topology/blob/master/virtual-organizations/README.md)
 
 The [Council](https://opensciencegrid.org/council/) governs the consortium ensuring that the OSG benefits the scientific mission of its stakeholders.
 


### PR DESCRIPTION
The Github yaml list is probably better than linking the [XML](https://topology.opensciencegrid.org/vosummary/xml?) but maybe instead we can link a pretty graph from the GRACC?

Alternatively, we can write a list in markdown fairly quickly.