### PR TITLE
Point the user docs link to the user docs

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -52,7 +52,7 @@
                   Docs
                 </a>
                 <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-                  <a class="dropdown-item" href="https://support.opensciencegrid.org/">For Users</a>
+                  <a class="dropdown-item" href="https://support.opensciencegrid.org/support/home">For Users</a>
                   <a class="dropdown-item" href="https://opensciencegrid.org/docs/">For Sysadmins</a>
                   <a class="dropdown-item" href="https://opensciencegrid.org/security/">Security</a>
                 </div>


### PR DESCRIPTION
The current link redirects Freshdesk agents to Freshdesk instead of the user docs page.