### PR TITLE
Dropped unnecessary meta tag

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,7 +2,6 @@
 <html lang="{{ site.lang | default: "en-US" }}">
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <link rel="icon" href="favicon.ico">
 
 {% seo %}


### PR DESCRIPTION
As near as I can tell, this meta tag existed to deal with a Chrome plug-in that was killed off over 5 years ago. E.g.: https://stackoverflow.com/questions/6771258/what-does-meta-http-equiv-x-ua-compatible-content-ie-edge-do