### PR TITLE
Add the Gemfile (but not the Gemfile.lock file) to the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 _site/
 .sass-cache/
 .jekyll-metadata
-Gemfile
 Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+gem "jekyll-theme-minimal"
+gem "jekyll"
+gem "jekyll-redirect-from"
+


### PR DESCRIPTION
Without the Gemfile, the Jekyll server container immediately crashed due
to the missing jekyll-theme-minimal gem.