### PR TITLE
Fix issue with relative link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -62,7 +62,7 @@
       </nav>
     </header>
     <div id="covid-19-mini-banner">
-      <p>Extra OSG Support for <a href="covid-19.html">COVID-19 Research</a></p>
+      <p>Extra OSG Support for <a href="/covid-19.html">COVID-19 Research</a></p>
     </div>
 
       <div class="container">


### PR DESCRIPTION
The link in the "Extra OSG Support for COVID-19 Research" banner appears to resolve to a non-existent page due to relative URIs.

For example, from the https://opensciencegrid.org/about/introduction/ page,
![image](https://user-images.githubusercontent.com/7332442/99925377-0eb2b500-2d92-11eb-88a6-d56302e4cada.png)

the link to "COVID-19 research" points to https://opensciencegrid.org/about/introduction/covid-19.html
![image](https://user-images.githubusercontent.com/7332442/99925386-140fff80-2d92-11eb-96c0-2e9eb3590677.png)

Local testing: I've edited the DOM to include the absolute-path reference (leading /) and it appears to be working consistently across all pages now.
