### PR TITLE
Remove COVID-19 banner.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -64,9 +64,6 @@
         </div> <!-- End Container -->
       </nav>
     </header>
-    <div id="covid-19-mini-banner">
-      <p>Extra OSG Support for <a href="/covid-19.html">COVID-19 Research</a></p>
-    </div>
 
       <div class="container">
         <main>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -7,6 +7,10 @@ body {
   color: #5a5a5a;
 }
 
+main {
+  padding-top: 15px;
+}
+
 /* CUSTOMIZE THE CAROUSEL
 -------------------------------------------------- */
 


### PR DESCRIPTION
Per discussion on OSG-ET list, we can remove the COVID-19 banner from the webpage.