### PR TITLE
Fixup SIUE link

### DIFF
--- a/campus-cyberinfrastructure.md
+++ b/campus-cyberinfrastructure.md
@@ -80,4 +80,4 @@ The Open Science Pool is a <a href="https://research.cs.wisc.edu/htcondor/" targ
 >- <a href="https://www.lsuhsc.edu/" target="_blank"> LSU Health</a>
 >- <a href="https://newscenter.nmsu.edu/Articles/view/14445/nsf-grant-brings-high-performance-computing-to-new-mexico-students-faculty" target="_blank"> New Mexico State University</a>
 >- <a href="https://www.pdx.edu/news/psu-receives-5m-federal-grant-improve-access-stem-education-underrepresented-students" target="_blank"> Portland State University</a>
->- <a href="https://oit.siu.edu/rcc/services/grant.php" target="_blank"> Southern Illinois University</a>
+>- <a href="https://www.siue.edu/its/cyberinfrastructure/" target="_blank"> Southern Illinois University Edwardsville</a>


### PR DESCRIPTION
SIUE admins pointed out that the old link points to their Carbondale campus and requested that we change the link