### PR TITLE
Adding baseurl so workflow file can change it for web preview

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,5 @@
+baseurl: ''
+
 theme: jekyll-theme-minimal
 title: Open Science Grid
 description: A national, distributed computing partnership for data-intensive research


### PR DESCRIPTION
Without this inclusion the /web-preview is not getting prepended to all the urls which will break all the links for the preview page